### PR TITLE
Turn off NaN detection to speed up training.

### DIFF
--- a/nsff_exp/run_nerf_helpers.py
+++ b/nsff_exp/run_nerf_helpers.py
@@ -1,5 +1,5 @@
 import torch
-torch.autograd.set_detect_anomaly(True)
+torch.autograd.set_detect_anomaly(False)
 import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np


### PR DESCRIPTION
Doesn't need to be merged, but currently Pytorch's NaN detection is turned on, which slows down training by 10-20% (didn't measure, but roughly that order of magnitude).